### PR TITLE
make geometry form render better in small windows

### DIFF
--- a/packages/ove-ui-launcher/src/steps/SpaceAndGeometry.jsx
+++ b/packages/ove-ui-launcher/src/steps/SpaceAndGeometry.jsx
@@ -200,10 +200,10 @@ export default class SpaceAndGeometry extends Component {
                                     <label className="control-label col-md-2">
                                         Geometry
                                     </label>
-                                    <label className="control-label col-sm-1">
-                                        x:
-                                    </label>
                                     <div className={notValidClasses.geometryCls_x}>
+                                        <label className="control-label col-sm-1">
+                                            x:
+                                        </label>
                                         <input
                                             ref="geometry_x"
                                             autoComplete="off"
@@ -217,10 +217,11 @@ export default class SpaceAndGeometry extends Component {
                                             onBlur={this.validationCheck} />
                                         <div className={notValidClasses.geometryValGrpCls_x}>{this.state.geometryValMsg ? this.state.geometryValMsg.x : ''}</div>
                                     </div>
-                                    <label className="control-label col-md-1">
-                                        y:
-                                    </label>
+
                                     <div className={notValidClasses.geometryCls_y}>
+                                        <label className="control-label col-md-1">
+                                            y:
+                                        </label>
                                         <input
                                             ref="geometry_y"
                                             autoComplete="off"
@@ -239,10 +240,10 @@ export default class SpaceAndGeometry extends Component {
                             <div className="col-md-12">
                                 <div className="form-group col-md-8 content form-block-holder">
                                     <label className="control-label col-md-2"/>
-                                    <label className="control-label col-md-1">
-                                        w:
-                                    </label>
                                     <div className={notValidClasses.geometryCls_w}>
+                                        <label className="control-label col-md-1">
+                                            w:
+                                        </label>
                                         <input
                                             ref="geometry_w"
                                             autoComplete="off"
@@ -256,10 +257,10 @@ export default class SpaceAndGeometry extends Component {
                                             onBlur={this.validationCheck} />
                                         <div className={notValidClasses.geometryValGrpCls_w}>{this.state.geometryValMsg ? this.state.geometryValMsg.w : ''}</div>
                                     </div>
-                                    <label className="control-label col-md-1">
-                                        h:
-                                    </label>
                                     <div className={notValidClasses.geometryCls_h}>
+                                        <label className="control-label col-md-1">
+                                            h:
+                                        </label>
                                         <input
                                             ref="geometry_h"
                                             autoComplete="off"


### PR DESCRIPTION
Previously the geometry form would not render properly if the browser window was too small:

![small-old](https://user-images.githubusercontent.com/338833/62866609-1d926700-bd09-11e9-8ac1-3afd50a3e751.png)

This PR fixes that:

![small-new](https://user-images.githubusercontent.com/338833/62866610-1d926700-bd09-11e9-812c-284e69c18248.png)

As a side effect, it changes the appearance of the form on larger pages slightly, from:

![big-old](https://user-images.githubusercontent.com/338833/62866674-529eb980-bd09-11e9-9f22-b6b4901bc845.png)

to:

 ![big-new](https://user-images.githubusercontent.com/338833/62866673-529eb980-bd09-11e9-97e3-7a073471496e.png)



